### PR TITLE
Add formatter= method to make the logging gem compatible with rails 7.1

### DIFF
--- a/lib/logging/rails_compat.rb
+++ b/lib/logging/rails_compat.rb
@@ -11,6 +11,9 @@ module Logging
     # A no-op implementation of the `formatter` method.
     def formatter; end
 
+    # A no-op implementation of the `formatter=` method.
+    def formatter=(_formatter); end
+
     # A no-op implementation of the +silence+ method. Setting of log levels
     # should be done during the Logging configuration. It is the author's
     # opinion that overriding the log level programmatically is a logical


### PR DESCRIPTION
Fix that comes from here https://github.com/TwP/logging/pull/246.
Temporary copy until the main gem merges in the fix.